### PR TITLE
Select parent when deleting circle

### DIFF
--- a/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/data-entry/hierarchy/building.component.ts
@@ -269,10 +269,12 @@ export class BuildingComponent implements OnDestroy {
 
   private removeNode(node: Initiative) {
     let hasFoundNode = false;
+    let parentNode: Initiative;
 
     const index = this.nodes[0].children.findIndex((c) => c.id === node.id);
     if (index > -1) {
       this.nodes[0].children.splice(index, 1);
+      parentNode = this.nodes[0];
     } else {
       this.nodes[0].traverse((n) => {
         if (hasFoundNode) return;
@@ -280,12 +282,17 @@ export class BuildingComponent implements OnDestroy {
         if (index > -1) {
           hasFoundNode = true;
           n.children.splice(index, 1);
+          parentNode = n;
         }
       });
     }
 
     this.sendInitiativesToOutliner();
     this.saveChanges();
+
+    if (parentNode) {
+      this.workspaceFacade.setSelectedInitiativeID(parentNode.id);
+    }
   }
 
   addNodeTo(node: Initiative, subNode: Initiative) {


### PR DESCRIPTION
Just a small but nice improvement to select the parent of the node just being deleted. Previously deleting a node would lead to jumping to the root node, somewhat jarringly. Now, we jump to the parent node instead.
