### PR TITLE
Add an option to read seed colour from the database

### DIFF
--- a/apps/maptio/src/app/modules/embed/pages/embed/embed.page.ts
+++ b/apps/maptio/src/app/modules/embed/pages/embed/embed.page.ts
@@ -10,22 +10,17 @@ import { CircleMapData } from '@maptio-shared/model/circle-map-data.interface';
 import { EmbeddableDatasetService } from '../../embeddable-dataset.service';
 import { CircleMapComponent } from '../../../circle-map/circle-map.component';
 
-
 @Component({
-    selector: 'maptio-embed',
-    templateUrl: './embed.page.html',
-    styleUrls: ['./embed.page.scss'],
-    imports: [CircleMapComponent]
+  selector: 'maptio-embed',
+  templateUrl: './embed.page.html',
+  styleUrls: ['./embed.page.scss'],
+  imports: [CircleMapComponent],
 })
 export class EmbedComponent implements OnInit, OnDestroy {
   private subs = new SubSink();
 
   datasetId: string | null = null;
   dataset: any; // eslint-disable-line @typescript-eslint/no-explicit-any
-
-  // Hardcoding the color as the colour is only stored in localstorage, which
-  // means we can't use it for publicly shareable and embeddable apps
-  seedColor = '#3599af';
 
   circleMapData$ = new BehaviorSubject<CircleMapData>(undefined);
 
@@ -35,7 +30,7 @@ export class EmbedComponent implements OnInit, OnDestroy {
     private route: ActivatedRoute,
     private cd: ChangeDetectorRef,
     private metaTagService: Meta,
-    private datasetService: EmbeddableDatasetService
+    private datasetService: EmbeddableDatasetService,
   ) {}
 
   ngOnInit(): void {
@@ -58,7 +53,7 @@ export class EmbedComponent implements OnInit, OnDestroy {
           const circleMapData: CircleMapData = {
             dataset: this.dataset,
             rootInitiative: this.dataset.initiative,
-            seedColor: this.seedColor,
+            seedColor: this.getSeedColor(),
           };
 
           this.circleMapData$.next(circleMapData);
@@ -82,5 +77,19 @@ export class EmbedComponent implements OnInit, OnDestroy {
    */
   onCreditPinch($event: TouchInput) {
     $event.preventDefault();
+  }
+
+  /**
+   * Read seed colour from the dataset if it's set
+   */
+  getSeedColor(): string {
+    if (this.dataset?.seedColor) {
+      return this.dataset.seedColor;
+    } else {
+      // If the colour is not set in the database, we can't default to the
+      // local storage colour on the embeddable version of the map, so we just
+      // use the default Maptio colour
+      return '#3599af';
+    }
   }
 }

--- a/apps/maptio/src/app/modules/workspace/components/canvas/mapping.component.ts
+++ b/apps/maptio/src/app/modules/workspace/components/canvas/mapping.component.ts
@@ -336,12 +336,14 @@ export class MappingComponent {
           this.datasetId = params['mapid'];
           this.slug = params['mapslug'];
           this.settings = this.mapSettingsService.get(this.datasetId);
-          this.mapColor$.next(this.settings.mapColor);
 
           this.cd.markForCheck();
         }),
         combineLatest(this.dataService.get()),
         map((data) => data[1]),
+        tap((data) => {
+          this.mapColor$.next(this.getSeedColor(data));
+        }),
         combineLatest(
           this.route.fragment,
           this.route.queryParams.pipe(distinct()),
@@ -554,5 +556,20 @@ export class MappingComponent {
     this.router.navigateByUrl(
       `/map/${this.datasetId}/${this.slug}/directory?member=${selected.shortid}`,
     );
+  }
+
+  /**
+   *  Read the seed color from the dataset or local storage
+   */
+  getSeedColor(data: any): string {
+    if (data?.dataset?.seedColor) {
+      // We added an option to define the seed colour in the database
+      return data.dataset.seedColor;
+    } else {
+      // This contains the seed color from the browser's local storage if it
+      // was set there by the user. Note this will be overridden if we set the
+      // colour globally in the database!
+      return this.settings.mapColor;
+    }
   }
 }

--- a/apps/maptio/src/app/shared/model/dataset.data.ts
+++ b/apps/maptio/src/app/shared/model/dataset.data.ts
@@ -28,6 +28,8 @@ export class DataSet implements Serializable<DataSet> {
   isEmbeddable = false;
   showDescriptions = false;
 
+  seedColor: string;
+
   lastEditedAt: number;
   lastEditedBy: User;
 
@@ -53,6 +55,7 @@ export class DataSet implements Serializable<DataSet> {
     deserialized.showDescriptions = input.showDescriptions
       ? input.showDescriptions
       : false;
+    deserialized.seedColor = input.seedColor;
 
     deserialized.lastEditedAt = input.lastEditedAt;
     deserialized.lastEditedBy = input.lastEditedBy


### PR DESCRIPTION
### Issue
This is a kind of a partial fix for #660 

### Description
At the moment, we can only change colours in a limited way - our colour picker is really a hue picker and we only store the chosen colour in local storage, so the change can't be propagated to all users. We've had multiple requests for #660 , but full on changes to how we deal with colour would be a bit time consuming (super fun, so I hope we get a chance to implement all that!), so for now we came up with the simplest possible trick: for each customer that needs to change the colour of the map, we can set the colour in the DB ourselves and then Maptio will use that colour.

This PR is for the "Maptio will read that colour" bit, i.e. at the point where we normally read the colour from local storage, we now first check whether or not it's set in the database. If it is, we use the colour from the database, ignoring what's in the user's local storage. If nothing is set in the database, this should behave as normal. 

One added bit here is that the embeddable map can now have a different colour too! Yay!


An example of what wasn't achievable previously (using #ed6a5a, "Vibrant Coral," as the seed colour):
<img width="1920" height="992" alt="Screenshot 2025-12-14 at 17 03 52" src="https://github.com/user-attachments/assets/c30d95d4-0911-45eb-8736-e624951eeab9" />

